### PR TITLE
Addition of postmaster

### DIFF
--- a/src/request/parser.rs
+++ b/src/request/parser.rs
@@ -429,7 +429,7 @@ impl<'x, 'y> Rfc5321Parser<'x, 'y> {
                     let value = value.data;
 
                     let is_valid = value.is_empty()
-                        || value.len() <= MAX_ADDRESS_LEN && at_count == 1 && lp_len > 0;
+                        || (value.len() <= MAX_ADDRESS_LEN && at_count == 1 && lp_len > 0) || value.to_ascii_lowercase() == "postmaster";
 
                     return Ok(is_valid.then_some(value));
                 }
@@ -1583,6 +1583,18 @@ mod tests {
             ("MAIL FROM:<@invalid>", Err(Error::InvalidSenderAddress)),
             (
                 "MAIL FROM:<hi@@invalid.org>",
+                Err(Error::InvalidSenderAddress),
+            ),
+            (
+                "MAIL FROM:<PostMaster>",
+                Ok(Request::Mail { from: "PostMaster".into() }),
+            ),
+            (
+                "MAIL FROM:<postmaster>",
+                Ok(Request::Mail { from: "postmaster".into() }),
+            ),
+            (
+                "MAIL FROM:<postmasterfail>",
                 Err(Error::InvalidSenderAddress),
             ),
             (


### PR DESCRIPTION
Hello,

I changed the code and added a test to control the validity and acceptance of postmaster as a requirement of [RFC 5321 (section 4.5.1)](https://www.rfc-editor.org/rfc/rfc5321.html#section-4.5.1):

> Any system that includes an SMTP server supporting mail relaying or delivery **MUST support the reserved mailbox "postmaster" as a case-insensitive local name**.  This postmaster address is not strictly necessary if the server always returns 554 on connection opening (as described in [Section 3.1](https://www.rfc-editor.org/rfc/rfc5321.html#section-3.1)).  The requirement to accept mail for postmaster implies that RCPT commands that specify a mailbox for postmaster at any of the domains for which the SMTP server provides mail service, as well as the special case of "RCPT TO:<Postmaster>" (with no domain specification), MUST be supported.

Thank you.