### PR TITLE
Fix parameter parser silently accepting garbage after address path

### DIFF
--- a/src/request/parser.rs
+++ b/src/request/parser.rs
@@ -980,7 +980,19 @@ impl<'x, 'y> Rfc5321Parser<'x, 'y> {
                 CONPERM if self.stop_char.is_ascii_whitespace() => {
                     params.flags |= MAIL_CONPERM;
                 }
-                0 => (),
+                0 => {
+                    // hashed_value_long() returned 0, meaning no alphanumeric
+                    // characters were found before hitting a non-keyword char.
+                    // If stop_char is whitespace/LF this is just extra spacing
+                    // between parameters (harmless). Otherwise it's garbage
+                    // like ">", "!", etc. that should be rejected.
+                    if !self.stop_char.is_ascii_whitespace() {
+                        self.seek_lf()?;
+                        return Err(Error::SyntaxError {
+                            syntax: "MAIL FROM:<reverse-path> [parameters]",
+                        });
+                    }
+                }
                 unknown => {
                     let mut param = Vec::with_capacity(16);
                     for ch in unknown.to_le_bytes() {
@@ -1101,7 +1113,14 @@ impl<'x, 'y> Rfc5321Parser<'x, 'y> {
                 CONNEG if self.stop_char.is_ascii_whitespace() => {
                     params.flags |= RCPT_CONNEG;
                 }
-                0 => (),
+                0 => {
+                    if !self.stop_char.is_ascii_whitespace() {
+                        self.seek_lf()?;
+                        return Err(Error::SyntaxError {
+                            syntax: "RCPT TO:<forward-path> [parameters]",
+                        });
+                    }
+                }
                 unknown => {
                     let mut param = Vec::with_capacity(16);
                     for ch in unknown.to_le_bytes() {
@@ -1666,6 +1685,27 @@ mod tests {
                 "MAIL FROM:<> SMTPUTF8=YES",
                 Err(Error::UnsupportedParameter {
                     param: "SMTPUTF8=YES".to_string(),
+                }),
+            ),
+            // Garbage after address path (non-alphanumeric chars that don't
+            // form valid parameter keywords should be rejected, not silently
+            // consumed)
+            (
+                "MAIL FROM:<>>>>>",
+                Err(Error::SyntaxError {
+                    syntax: "MAIL FROM:<reverse-path> [parameters]",
+                }),
+            ),
+            (
+                "MAIL FROM:<a@b.com>>>",
+                Err(Error::SyntaxError {
+                    syntax: "MAIL FROM:<reverse-path> [parameters]",
+                }),
+            ),
+            (
+                "RCPT TO:<>>>>>",
+                Err(Error::SyntaxError {
+                    syntax: "RCPT TO:<forward-path> [parameters]",
                 }),
             ),
             // Parameters


### PR DESCRIPTION
## Summary

The `mail_from_parameters()` and `rcpt_to_parameters()` functions silently accept non-alphanumeric garbage characters after the closing `>` of a MAIL FROM / RCPT TO path.

For example, `MAIL FROM:<>>>>>\r\n` is parsed as a valid null reverse path (equivalent to `MAIL FROM:<>\r\n`) because:

1. `address()` correctly sees `<>` and returns `Some("")` (null reverse path)
2. The remaining `>>>>` enter `mail_from_parameters()`
3. Each `>` feeds into `hashed_value_long()`, which can't accumulate any alphanumeric chars, so it returns `key = 0`
4. The `0 => ()` branch silently skips the garbage

Per RFC 5321 §4.1.2, after the closing `>`, the only valid input is `SP esmtp-param` or `CRLF`, where `esmtp-param` keywords must start with `ALPHA / DIGIT`. Characters like `>`, `!`, `@`, `#` etc. should not be silently consumed.

This also affects `rcpt_to_parameters()` which has the same `0 => ()` pattern.

## Fix

When `hashed_value_long()` returns 0 and `stop_char` is not whitespace/LF (meaning a non-alphanumeric character was hit before any keyword could form), return a `SyntaxError` instead of silently continuing.

## Test cases added

- `MAIL FROM:<>>>>>` → `Err(SyntaxError)` (was incorrectly `Ok` with empty address)
- `MAIL FROM:<a@b.com>>>` → `Err(SyntaxError)` (was incorrectly `Ok`)
- `RCPT TO:<>>>>>` → `Err(SyntaxError)` (was incorrectly `Ok` with empty address)