### PR TITLE
Add Request::name() method returning SMTP command name

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,6 +41,32 @@ pub enum Request<T> {
     Quit,
 }
 
+impl<T> Request<T> {
+    /// Returns the SMTP command name for this request variant.
+    pub fn name(&self) -> &'static str {
+        match self {
+            Request::Ehlo { .. } => "EHLO",
+            Request::Helo { .. } => "HELO",
+            Request::Lhlo { .. } => "LHLO",
+            Request::Mail { .. } => "MAIL",
+            Request::Rcpt { .. } => "RCPT",
+            Request::Data => "DATA",
+            Request::Bdat { .. } => "BDAT",
+            Request::Auth { .. } => "AUTH",
+            Request::Noop { .. } => "NOOP",
+            Request::Vrfy { .. } => "VRFY",
+            Request::Expn { .. } => "EXPN",
+            Request::Help { .. } => "HELP",
+            Request::Etrn { .. } => "ETRN",
+            Request::Atrn { .. } => "ATRN",
+            Request::Burl { .. } => "BURL",
+            Request::StartTls => "STARTTLS",
+            Request::Rset => "RSET",
+            Request::Quit => "QUIT",
+        }
+    }
+}
+
 impl Request<Cow<'_, str>> {
     pub fn into_owned(self) -> Request<String> {
         match self {

--- a/src/request/parser.rs
+++ b/src/request/parser.rs
@@ -2198,6 +2198,42 @@ mod tests {
         }
     }
 
+    #[test]
+    fn request_name() {
+        assert_eq!(Request::<String>::Quit.name(), "QUIT");
+        assert_eq!(Request::<String>::Data.name(), "DATA");
+        assert_eq!(Request::<String>::Rset.name(), "RSET");
+        assert_eq!(Request::<String>::StartTls.name(), "STARTTLS");
+        assert_eq!(
+            Request::Ehlo::<Cow<'_, str>> {
+                host: "test.com".into()
+            }
+            .name(),
+            "EHLO"
+        );
+        assert_eq!(
+            Request::Helo::<Cow<'_, str>> {
+                host: "test.com".into()
+            }
+            .name(),
+            "HELO"
+        );
+        assert_eq!(
+            Request::Mail {
+                from: MailFrom::<Cow<'_, str>>::default()
+            }
+            .name(),
+            "MAIL"
+        );
+        assert_eq!(
+            Request::Rcpt {
+                to: RcptTo::<Cow<'_, str>>::default()
+            }
+            .name(),
+            "RCPT"
+        );
+    }
+
     impl<'a> From<&'a str> for MailFrom<Cow<'a, str>> {
         fn from(value: &'a str) -> Self {
             Self {


### PR DESCRIPTION
## Summary

Add a `name()` method to `Request<T>` that returns the SMTP command name as a `&'static str` (e.g. `"EHLO"`, `"MAIL"`, `"RCPT"`, `"QUIT"`).

This is useful for logging, tracing, and metrics where consumers need a human-readable label for the command variant. Currently every consumer of this crate has to write their own match expression to map request variants to command name strings — this is trivial boilerplate that belongs in the library.

## Example

```rust
let req = Request::parse(&mut input.iter())?.into_owned();
println!("Received command: {}", req.name()); // "MAIL", "RCPT", "EHLO", etc.
```

## Changes

- Added `impl<T> Request<T>` block with `pub fn name(&self) -> &'static str` in `src/lib.rs`
- Added `request_name` test in `src/request/parser.rs`